### PR TITLE
Remove unnecessary empty stack check

### DIFF
--- a/bytecodes/04.m
+++ b/bytecodes/04.m
@@ -1,0 +1,2 @@
+push \
+pall

--- a/main.c
+++ b/main.c
@@ -14,7 +14,7 @@ globals_t globals = {NULL, NULL, true, false};
 int main(int argc, char *argv[])
 {
 	char line[500];
-	char *filename = argv[1];
+	char *filename;
 	unsigned int line_number = 1;
 	stack_t *our_stack = NULL;
 
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "USAGE: monty file\n");
 		exit(EXIT_FAILURE);
 	}
+	filename = argv[1];
 	globals.file = fopen(filename, "r");
 	if (globals.file == NULL)
 	{
@@ -78,14 +79,11 @@ void free_our_stack(stack_t *our_stack)
 {
 	stack_t *current;
 
-	if (our_stack != NULL)
+	while (our_stack != NULL)
 	{
-		while (our_stack != NULL)
-		{
-			current = our_stack->next;
-			free(our_stack);
-			our_stack = current;
-		}
+		current = our_stack->next;
+		free(our_stack);
+		our_stack = current;
 	}
 }
 

--- a/ops1.c
+++ b/ops1.c
@@ -45,7 +45,7 @@ void push_to_stack(stack_t **our_stack, unsigned int line_number)
 		*our_stack = new_node;
 	}
 	else
-		implement_enqueue(our_stack, arg);
+		implement_enqueue(our_stack, arg); /*Add the value to the queue*/
 }
 /**
  * print_all_stack - Prints the data in a stack
@@ -59,15 +59,11 @@ void print_all_stack(stack_t **our_stack, unsigned int line_number)
 
 	UNUSED(line_number);
 
-	/*Print only if not empty*/
-	if (*our_stack != NULL)
+	current = *our_stack;
+	while (current != NULL)
 	{
-		current = *our_stack;
-		while (current != NULL)
-		{
-			printf("%d\n", current->n);
-			current = current->next;
-		}
+		printf("%d\n", current->n);
+		current = current->next;
 	}
 }
 /**

--- a/split_line.c
+++ b/split_line.c
@@ -25,6 +25,7 @@ void split_line(char *line, unsigned int line_number, stack_t **our_stack)
 
 	num_instructions = sizeof(instructions) / sizeof(instructions[0]);
 	string = strtok(line, DELIMITER);
+	/*Check if string is a valid opcode*/
 	if (check_opcode(string, instructions, num_instructions))
 	{
 		globals.argument = strtok(NULL, DELIMITER);


### PR DESCRIPTION
Remove the check for empty stack in print_all_stack and free_our_stack because the loop isn't going to be executed anyway if the stack/queue was empty.
Also, I've changed char *filename = argv[1]; to char *filename; and moved the definition after making sure argc is 2